### PR TITLE
Catch Exception instead of Throwable in BoundedLocalCache.java

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -412,14 +412,14 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
     Runnable task = () -> {
       try {
         removalListener().onRemoval(key, value, cause);
-      } catch (Throwable t) {
-        logger.log(Level.WARNING, "Exception thrown by removal listener", t);
+      } catch (Exception e) {
+        logger.log(Level.WARNING, "Exception thrown by removal listener", e);
       }
     };
     try {
       executor.execute(task);
-    } catch (Throwable t) {
-      logger.log(Level.ERROR, "Exception thrown when submitting removal listener", t);
+    } catch (Exception e) {
+      logger.log(Level.ERROR, "Exception thrown when submitting removal listener", e);
       task.run();
     }
   }


### PR DESCRIPTION
This pull request is for issue #3. 

- Class name: BoundedLocalCache.java
- Class location :caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java

It resolves the code smell in BoundedLocalCache.java where a Throwable was being caught instead of an Exception.