### PR TITLE
Correct this "|" to "||" in BoundedLocalCache.java

### DIFF
--- a/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
+++ b/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java
@@ -997,9 +997,11 @@ abstract class BoundedLocalCache<K, V> extends BLCHeader.DrainStatusRef
     if (isComputingAsync(node.getValue())) {
       return false;
     }
+    boolean expiredAfterWrite = expiresAfterWrite() && (now - node.getWriteTime() >= expiresAfterWriteNanos());
+    boolean expiredvariable = expiresVariable() && (now - node.getVariableTime() >= 0);
     return (expiresAfterAccess() && (now - node.getAccessTime() >= expiresAfterAccessNanos()))
-        | (expiresAfterWrite() && (now - node.getWriteTime() >= expiresAfterWriteNanos()))
-        | (expiresVariable() && (now - node.getVariableTime() >= 0));
+        || expiredAfterWrite
+        || expiredvariable;
   }
 
   /**


### PR DESCRIPTION
This pull request is for issue #5 

Class name: BoundedLocalCache.java
Class location :caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedLocalCache.java We change the '|' to '||' to make sure all booleans are evaluated