### PR TITLE
Sadman potential buffer overflow from usage of unsafe function

### DIFF
--- a/simulator/src/main/resources/com/github/benmanes/caffeine/cache/simulator/parser/lirs/clock-pro.c
+++ b/simulator/src/main/resources/com/github/benmanes/caffeine/cache/simulator/parser/lirs/clock-pro.c
@@ -99,7 +99,8 @@ int main()
     return 1;
   }
 
-  strncpy(para_file_name, argv[1]);
+  strncpy(para_file_name, argv[1], sizeof(para_file_name) - 5);
+  para_file_name[sizeof(para_file_name) - 5] = '\0';
   strcat(para_file_name, ".par");
   para_fp = openReadFile(para_file_name);
 


### PR DESCRIPTION
Fixed `strcpy(para_file_name, argv[1]);`

to `strncpy(para_file_name, argv[1], sizeof(para_file_name) - 5);
  para_file_name[sizeof(para_file_name) - 5] = '\0';`

This helps to reduction in memory corruption and undefined behavior. This PR resolves [Issue 13](https://github.com/Sadman-Arif-Wamim/caffeine/issues/13)



