### PR TITLE
Fixed division by zero potential vulnerability in clock-pro.c

### DIFF
--- a/simulator/src/main/resources/com/github/benmanes/caffeine/cache/simulator/parser/lirs/clock-pro.c
+++ b/simulator/src/main/resources/com/github/benmanes/caffeine/cache/simulator/parser/lirs/clock-pro.c
@@ -196,7 +196,9 @@ int main()
 
     printf("total blocks refs = %ld  number of misses = %ld ==> hit rate = %2.1f\%\n",  total_pg_refs, num_pg_flt, (1-(float)num_pg_flt/warm_pg_refs)*100);
 
-    fprintf(cuv_fp, "%5ld  %2.1f\n", mem_size, 100-(float)num_pg_flt/warm_pg_refs*100);
+    if(warm_pg_refs>0){
+      fprintf(cuv_fp, "%5ld  %2.1f\n", mem_size, 100-(float)num_pg_flt/warm_pg_refs*100);
+    }
 
     if (sln_fp)
       fclose(sln_fp);


### PR DESCRIPTION
This is a PR to address a potential division by zero vulnerability in clock-pro.c.

I have added a simple if statement to make sure the divisor is bigger than zero to avoid any problems.